### PR TITLE
24 prep envp for execve

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
 			"name": "test",
 			"type": "cppdbg",
 			"request": "launch",
-			"program": "${workspaceFolder}/tester",
+			"program": "${workspaceFolder}/test",
 			"args": [],
 			"stopAtEntry": true,
 			"cwd": "${fileDirname}",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
 		"mini_error.h": "c",
 		"minishell_error.h": "c",
 		"minishell.h": "c",
-		"test.h": "c"
+		"test.h": "c",
+		"env_envp.h": "c"
 	}
 }

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ SRC :=	main.c \
 		prompt_replace_small.c \
 		prompt_replace_w.c \
 		lexer_check_syntax.c \
-		utils.c
+		utils.c \
+		env_envp.c
 SRCS := $(addprefix $(SRC_DIR)/, $(SRC))
 
 # Objects
@@ -66,7 +67,8 @@ TEST_SRC := test_main.c \
 			test_replace_token.c \
 			test_prompt.c \
 			test_hashtable.c \
-			test_check_syntax.c
+			test_check_syntax.c \
+			test_env_envp.c
 TEST_SRCS := $(addprefix $(TEST_DIR)/, $(TEST_SRC))
 TEST_OBJ := $(TEST_SRC:.c=.o)
 TEST_OBJS := $(addprefix $(TEST_DIR)/, $(TEST_OBJ))

--- a/inc/env_envp.h
+++ b/inc/env_envp.h
@@ -1,0 +1,24 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env_envp.h                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/06/28 08:11:46 by gwolf             #+#    #+#             */
+/*   Updated: 2023/06/28 18:25:56 by gwolf            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef ENV_ENVP_H
+# define ENV_ENVP_H
+
+# include <stdint.h>
+
+# include "minishell_error.h"
+# include "hashtable.h"
+
+t_error	ft_envp_create(t_hashtable *ht, char ***envp);
+t_error	ft_envp_destroy(char **envp);
+
+#endif

--- a/inc/env_envp.h
+++ b/inc/env_envp.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/28 08:11:46 by gwolf             #+#    #+#             */
-/*   Updated: 2023/06/28 18:25:56 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/07/07 12:10:03 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,6 @@
 # include "hashtable.h"
 
 t_error	ft_envp_create(t_hashtable *ht, char ***envp);
-t_error	ft_envp_destroy(char **envp);
+t_error	ft_envp_destroy(char ***envp);
 
 #endif

--- a/inc/hashtable.h
+++ b/inc/hashtable.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/15 18:07:23 by gwolf             #+#    #+#             */
-/*   Updated: 2023/06/06 15:10:04 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/07/07 11:15:29 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,9 +51,9 @@ typedef uint64_t			t_hashfunction (const char *, size_t);
  * @param next Pointer to the next node in this hashtable bucket.
  */
 typedef struct s_env_var {
-	const char			*env_string;
+	char				*env_string;
 	size_t				keylen;
-	const char			*value;
+	char				*value;
 	struct s_env_var	*next;
 }	t_env_var;
 
@@ -74,6 +74,7 @@ typedef struct s_env_var {
 typedef struct s_hashtable {
 	uint32_t		size;
 	t_hashfunction	*hash;
+	uint32_t		num_elements;
 	t_env_var		**elements;
 }	t_hashtable;
 
@@ -85,15 +86,15 @@ void		ft_hashtable_destroy(t_hashtable *ht);
 
 //hashtable_utils.c
 t_error		ft_hashtable_insert(
-				t_hashtable *ht, const char *string, size_t keylen);
+				t_hashtable *ht, char *string, size_t keylen);
 t_env_var	*ft_hashtable_lookup(
 				t_hashtable *ht, const char *string, size_t keylen);
 t_error		ft_hashtable_delete(
-				t_hashtable *ht, const char *string, size_t keylen);
+				t_hashtable *ht, char *string, size_t keylen);
 void		ft_hashtable_print(t_hashtable *ht);
 
 //hashtable_utils2.c
 t_error		ft_hashtable_swap(
-				t_hashtable *ht, const char *string, size_t keylen);
+				t_hashtable *ht, char *string, size_t keylen);
 
 #endif

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/12 15:20:30 by gwolf             #+#    #+#             */
-/*   Updated: 2023/06/24 11:26:10 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/07/07 11:30:48 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@
 # include "libft.h"
 # include "minishell_error.h"
 # include "hashtable.h"
-# include "lexer_check_syntax.h"
+
 
 # define HASHTABLE_SIZE 10
 # define MAX_SHLVL 10
@@ -132,6 +132,5 @@ t_error	ft_prompt_replace_u(char **replacement, t_hashtable *sym_tab);
 
 //prompt_replace_w.c
 t_error	ft_prompt_replace_w(char **replacement, t_hashtable *sym_tab);
-
 
 #endif

--- a/inc/test.h
+++ b/inc/test.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/02 10:32:12 by gwolf             #+#    #+#             */
-/*   Updated: 2023/06/24 10:28:43 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/07/07 11:32:04 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,5 +19,6 @@ void	test_hashtable(void);
 void	test_replace_token(void);
 void	test_prompt(void);
 void	test_check_syntax(void);
+void	test_env_envp(void);
 
 #endif

--- a/src/env_envp.c
+++ b/src/env_envp.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/27 18:09:38 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/07 12:01:31 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/07/07 12:04:45 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,6 +66,7 @@ t_error	ft_envp_create(t_hashtable *ht, char ***envp)
 /**
  * @brief Destroy envp.
  *
+ * Check if envp exists. If yes:
  * Free the envp and set to NULL.
  * Does not free elements.
  *
@@ -74,7 +75,10 @@ t_error	ft_envp_create(t_hashtable *ht, char ***envp)
  */
 t_error	ft_envp_destroy(char ***envp)
 {
-	free(*envp);
-	*envp = NULL;
+	if (*envp)
+	{
+		free(*envp);
+		*envp = NULL;
+	}
 	return (SUCCESS);
 }

--- a/src/env_envp.c
+++ b/src/env_envp.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/27 18:09:38 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/07 11:43:30 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/07/07 12:01:31 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,13 +66,15 @@ t_error	ft_envp_create(t_hashtable *ht, char ***envp)
 /**
  * @brief Destroy envp.
  *
- * Just free the envp. Does not free elements.
+ * Free the envp and set to NULL.
+ * Does not free elements.
  *
  * @param envp The pointer to free.
  * @return t_error SUCCESS
  */
-t_error	ft_envp_destroy(char **envp)
+t_error	ft_envp_destroy(char ***envp)
 {
-	free(envp);
+	free(*envp);
+	*envp = NULL;
 	return (SUCCESS);
 }

--- a/src/env_envp.c
+++ b/src/env_envp.c
@@ -1,0 +1,78 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env_envp.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/06/27 18:09:38 by gwolf             #+#    #+#             */
+/*   Updated: 2023/07/07 11:43:30 by gwolf            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "env_envp.h"
+
+/**
+ * @brief Loop through all elements and copy the pointers.
+ *
+ * @param ht Environment table which to copy.
+ * @param envp Where to save pointers.
+ * @return t_error SUCCESS
+ */
+static t_error	ft_envp_fill(t_hashtable *ht, char **envp)
+{
+	uint32_t	i;
+	t_env_var	*tmp;
+
+	i = 0;
+	while (i < ht->size)
+	{
+		if (ht->elements[i])
+		{
+			tmp = ht->elements[i];
+			while (tmp != NULL)
+			{
+				*envp++ = tmp->env_string;
+				tmp = tmp->next;
+			}
+		}
+		i++;
+	}
+	*envp = NULL;
+	return (SUCCESS);
+}
+
+/**
+ * @brief Malloc a NULL-terminated envp
+ *
+ * Malloc num_elements of hashtable plus 1 for terminator.
+ * Fetch all elements with ft_envp_fill().
+ *
+ * @param ht Environment from which to copy.
+ * @param envp Pointer to char**, where to save.
+ * @return t_error ERR_EMPTY, ERR_MALLOC, SUCCESS
+ */
+t_error	ft_envp_create(t_hashtable *ht, char ***envp)
+{
+	if (!ht || !envp)
+		return (ERR_EMPTY);
+	*envp = malloc(sizeof(char *) * (ht->num_elements + 1));
+	if (!*envp)
+		return (ERR_MALLOC);
+	ft_envp_fill(ht, *envp);
+	return (SUCCESS);
+}
+
+/**
+ * @brief Destroy envp.
+ *
+ * Just free the envp. Does not free elements.
+ *
+ * @param envp The pointer to free.
+ * @return t_error SUCCESS
+ */
+t_error	ft_envp_destroy(char **envp)
+{
+	free(envp);
+	return (SUCCESS);
+}

--- a/src/hashtable_generate.c
+++ b/src/hashtable_generate.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/15 18:13:36 by gwolf             #+#    #+#             */
-/*   Updated: 2023/05/25 22:02:47 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/07/07 11:19:41 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,7 @@ t_hashtable	*ft_hashtable_create(uint32_t size, t_hashfunction *hf)
 		return (NULL);
 	ht->size = size;
 	ht->hash = hf;
+	ht->num_elements = 0;
 	ht->elements = ft_calloc(sizeof(t_env_var *), ht->size);
 	if (!ht->elements)
 	{
@@ -90,7 +91,7 @@ void	ft_hashtable_destroy(t_hashtable *ht)
 		{
 			tmp = ht->elements[i];
 			ht->elements[i] = ht->elements[i]->next;
-			free((void *)(tmp->env_string));
+			free(tmp->env_string);
 			free(tmp);
 		}
 		i++;

--- a/src/hashtable_utils.c
+++ b/src/hashtable_utils.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/19 11:17:06 by gwolf             #+#    #+#             */
-/*   Updated: 2023/06/08 15:11:18 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/07/07 11:22:30 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,7 +48,7 @@ static size_t	ft_hashtable_index(
  * @param keylen Length of env_var (everything before =)
  * @return t_error SUCCESS, ERR_EMPTY, ERR_MALLOC, ERR_HT_NO_INSERT
  */
-t_error	ft_hashtable_insert(t_hashtable *ht, const char *string, size_t keylen)
+t_error	ft_hashtable_insert(t_hashtable *ht, char *string, size_t keylen)
 {
 	size_t		index;
 	t_env_var	*env_var;
@@ -66,6 +66,7 @@ t_error	ft_hashtable_insert(t_hashtable *ht, const char *string, size_t keylen)
 	env_var->value = string + keylen + 1;
 	env_var->next = ht->elements[index];
 	ht->elements[index] = env_var;
+	ht->num_elements++;
 	return (SUCCESS);
 }
 
@@ -107,7 +108,7 @@ t_env_var	*ft_hashtable_lookup(
  * Loop through the list and update tmp and prev pointers.
  * If tmp == NULL no element was found.
  * If prev == NULL element is at start of list.
- * If element is found free void casted string, since it is const.
+ * If element is found free.
  * Then free element and update next pointer.
  * @param ht Hashtable in which to delete one element
  * @param string env_string which should be deleted
@@ -115,7 +116,7 @@ t_env_var	*ft_hashtable_lookup(
  * @return t_error SUCCESS, ERR_EMPTY, ERR_HT_NO_DELETE
  */
 t_error	ft_hashtable_delete(
-	t_hashtable *ht, const char *string, size_t keylen)
+	t_hashtable *ht, char *string, size_t keylen)
 {
 	size_t		index;
 	t_env_var	*tmp;
@@ -138,8 +139,9 @@ t_error	ft_hashtable_delete(
 		ht->elements[index] = tmp->next;
 	else
 		prev->next = tmp->next;
-	free((void *)tmp->env_string);
+	free(tmp->env_string);
 	free(tmp);
+	ht->num_elements--;
 	return (SUCCESS);
 }
 
@@ -174,5 +176,6 @@ void	ft_hashtable_print(t_hashtable *ht)
 		}
 		i++;
 	}
+	printf("Number of elements: %d\n", ht->num_elements);
 	printf("End Table\n");
 }

--- a/src/hashtable_utils2.c
+++ b/src/hashtable_utils2.c
@@ -6,13 +6,13 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/06 14:47:39 by gwolf             #+#    #+#             */
-/*   Updated: 2023/06/06 15:24:11 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/07/07 11:22:49 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "hashtable.h"
 
-t_error	ft_hashtable_swap(t_hashtable *ht, const char *string, size_t keylen)
+t_error	ft_hashtable_swap(t_hashtable *ht, char *string, size_t keylen)
 {
 	t_env_var	*env_var;
 
@@ -21,7 +21,7 @@ t_error	ft_hashtable_swap(t_hashtable *ht, const char *string, size_t keylen)
 	env_var = ft_hashtable_lookup(ht, string, keylen);
 	if (!env_var)
 		return (ERR_HT_NO_SWAP);
-	free((void *)env_var->env_string);
+	free(env_var->env_string);
 	env_var->env_string = string;
 	env_var->value = string + keylen + 1;
 	return (SUCCESS);

--- a/tests/test_env_envp.c
+++ b/tests/test_env_envp.c
@@ -1,0 +1,50 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   test_env_envp.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/06/28 08:17:46 by gwolf             #+#    #+#             */
+/*   Updated: 2023/07/01 18:28:57 by gwolf            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "test.h"
+
+t_hashtable	*symtab;
+char		**envp;
+
+void	test_env_envp_two(void)
+{
+	size_t		i;
+
+	ft_hashtable_insert(symtab, "TEST=This is a value", 4);
+	ft_hashtable_insert(symtab, "TEST2=Another value", 5);
+	ft_envp_create(symtab, &envp);
+	printf("This is envp[0]: %p\n", envp[0]);
+	printf("This is envp[1]: %p\n", envp[1]);
+	printf("This is envp[2]: %p\n", envp[2]);
+	i = 0;
+	while (envp[i])
+	{
+		printf("This is %lu. symbol: %s\n", i + 1, envp[i]);
+		i++;
+	}
+	ft_envp_destroy(envp);
+
+}
+
+void	test_env_envp_empty(void)
+{
+	ft_envp_create(symtab, &envp);
+	printf("This is envp[0]: %p\n", envp[0]);
+	ft_envp_destroy(envp);
+}
+
+void	test_env_envp(void)
+{
+	symtab = ft_hashtable_create(10, ft_hash_fnv1);
+	//test_env_envp_empty();
+	test_env_envp_two();
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/02 10:40:30 by gwolf             #+#    #+#             */
-/*   Updated: 2023/06/24 10:28:03 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/07/07 11:32:54 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,8 +15,9 @@
 int	main(void)
 {
 	//test_hashtable();
-	//test_replace_token();
-	//test_prompt();
+	////test_replace_token();
+	////test_prompt();
 	test_check_syntax();
+	test_env_envp();
 	return (0);
 }


### PR DESCRIPTION
Simple addition of two functions which create and destroy a char **array (envp). This can be passed to execve.

1. New var num_elements in t_hashtable
Hashtable now has a var to save the number of elements. The functions ft_hashtable_insert() and ft_hashtable_delete() increase and decrease this counter.

2. ft_envp_create()
Malloc an array of size num_elements plus 1 (for NULL termination). Copy the pointers from hashtable into this array. Last element is set to NULL

3. ft_envp_destroy()
Check if its exists. If yes free (dont touch the elements themselves), and set to NULL. 

4. Idea: The envp only needs to be destroyed, if environment variables are added / deleted (i.e. it gets bigger/smaller). Maybe we can implement a check before creation of envp, if the environment has changed. If only the values have changed, then only the pointers need to be updated.

Closes #24 