### PR TITLE
37 env variables dont necessarily need a value

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,8 @@
 		"string_view": "c",
 		"mod_expand.h": "c",
 		"minishell_config.h": "c",
-		"mod_prompt.h": "c"
+		"mod_prompt.h": "c",
+		"mod_env.h": "c",
+		"mod_builtin.h": "c"
 	}
 }

--- a/inc/hashtable.h
+++ b/inc/hashtable.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/15 18:07:23 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 17:00:06 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 18:01:52 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,6 +93,6 @@ t_env_var	*ft_hashtable_lookup(
 t_err		ft_hashtable_delete(
 				t_hashtable *ht, char *string, size_t keylen);
 t_err		ft_hashtable_swap(
-				t_hashtable *ht, char *string, size_t keylen);
+				t_hashtable *ht, char *string, size_t keylen, bool has_value);
 
 #endif

--- a/inc/hashtable.h
+++ b/inc/hashtable.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/15 18:07:23 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/30 14:55:22 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 17:00:06 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,6 +53,7 @@ typedef uint64_t			t_hashfunction (const char *, size_t);
 typedef struct s_env_var {
 	char				*env_string;
 	size_t				keylen;
+	bool				has_value;
 	char				*value;
 	struct s_env_var	*next;
 }	t_env_var;
@@ -86,7 +87,7 @@ void		ft_hashtable_destroy(t_hashtable *ht);
 //hashtable_utils.c
 size_t		ft_hashtable_index(t_hashtable *ht, const char *key, size_t keylen);
 t_err		ft_hashtable_insert(
-				t_hashtable *ht, char *string, size_t keylen);
+				t_hashtable *ht, char *string, size_t keylen, bool has_value);
 t_env_var	*ft_hashtable_lookup(
 				t_hashtable *ht, const char *string, size_t keylen);
 t_err		ft_hashtable_delete(

--- a/inc/hashtable.h
+++ b/inc/hashtable.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/15 18:07:23 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 18:01:52 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 20:15:48 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,6 +47,7 @@ typedef uint64_t			t_hashfunction (const char *, size_t);
  * This node saves one env variable.
  * @param env_string The whole env string (e.g. PWD=path/to/pwd).
  * @param keylen The length of the env variable name.
+ * @param has_value Saves if the variable was assigned a value (with '=')
  * @param value Pointer to the start of the env value.
  * @param next Pointer to the next node in this hashtable bucket.
  */
@@ -70,12 +71,15 @@ typedef struct s_env_var {
  *
  * @param size How many buckets hashtable has.
  * @param hash The used hash function.
+ * @param num_elements How many elements are save in hashtable.
+ * @param num_values How many of the saved elements have a value saved.
  * @param elements Pointer to the individual buckets.
  */
 typedef struct s_hashtable {
 	uint32_t		size;
 	t_hashfunction	*hash;
 	uint32_t		num_elements;
+	uint32_t		num_values;
 	t_env_var		**elements;
 }	t_hashtable;
 

--- a/inc/mod_builtin.h
+++ b/inc/mod_builtin.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 17:57:20 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 18:05:12 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 21:39:26 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@
 //IMPORT MOD_ENV
 t_err	ft_create_pwd_value(char **pwd_value);
 t_err	ft_create_env_pwd(char **pwd);
-t_err	ft_envp_create(t_hashtable *ht, char ***envp);
+t_err	ft_envp_create_all(t_hashtable *ht, char ***envp);
 t_err	ft_envp_destroy(char ***envp);
 
 //utils.c

--- a/inc/mod_builtin.h
+++ b/inc/mod_builtin.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 17:57:20 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/25 23:46:41 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 18:05:12 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,8 @@ t_err	ft_envp_destroy(char ***envp);
 //utils.c
 t_err	ft_get_array_size(char **array, size_t *size);
 t_err	ft_get_env_keylen(char *str, size_t *len);
-t_err	ft_update_env_var(t_hashtable *env_tab, char *env_str, size_t keylen);
+t_err	ft_update_env_var(t_hashtable *env_tab,
+			char *env_str, size_t keylen, bool has_value);
 void	ft_swap(char **str1, char **str2);
 void	ft_quicksort_strings(char **arr, int low, int high);
 

--- a/inc/mod_env.h
+++ b/inc/mod_env.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/21 11:41:48 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/21 16:51:26 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 17:56:09 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@ extern char	**environ;
 //env_setup.c
 t_err	ft_env_setup(t_hashtable **env_table);
 t_err	ft_import_environ(t_hashtable *env_table);
+t_err	ft_copy_environ_str(t_hashtable *env_table, char *environ_str);
 t_err	ft_insert_env_pwd(t_hashtable *env_table);
 t_err	ft_insert_env_shlvl(t_hashtable *env_table);
 
@@ -45,5 +46,8 @@ t_err	ft_increment_shlvl(t_hashtable *env_table);
 t_err	ft_envp_fill(t_hashtable *ht, char **envp);
 t_err	ft_envp_create(t_hashtable *ht, char ***envp);
 t_err	ft_envp_destroy(char ***envp);
+
+//Import from mod_builtin
+t_err	ft_get_env_keylen(char *str, size_t *len);
 
 #endif

--- a/inc/mod_env.h
+++ b/inc/mod_env.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/21 11:41:48 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 17:56:09 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 21:36:49 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,8 +43,9 @@ t_err	ft_create_env_shlvl(char **shlvl, int val);
 t_err	ft_increment_shlvl(t_hashtable *env_table);
 
 //env_envp.c
-t_err	ft_envp_fill(t_hashtable *ht, char **envp);
+t_err	ft_envp_fill(t_hashtable *ht, char **envp, bool all);
 t_err	ft_envp_create(t_hashtable *ht, char ***envp);
+t_err	ft_envp_create_all(t_hashtable *ht, char ***envp);
 t_err	ft_envp_destroy(char ***envp);
 
 //Import from mod_builtin

--- a/inc/test.h
+++ b/inc/test.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/02 10:32:12 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/11 11:10:02 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 20:31:54 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,6 +39,7 @@ void	test_free_argv_elem(size_t index);
 void	test_hashtable_pretty_print(t_hashtable *ht);
 void	test_print_tkn_list(t_tkn_list *head);
 void	test_print_t_type(t_type type);
+void	test_print_str_array(char **array);
 
 void	test_buffer(void);
 void	test_hashtable(void);

--- a/src/builtin_cd.c
+++ b/src/builtin_cd.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 17:57:01 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/28 17:48:14 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 18:05:55 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -126,13 +126,13 @@ t_err	ft_change_dir(char *path, t_hashtable *env_tab, char *oldpwd)
 		err = ft_create_env_pwd(&pwd);
 		if (err != SUCCESS)
 			return (err);
-		err = ft_update_env_var(env_tab, pwd, 3);
+		err = ft_update_env_var(env_tab, pwd, 3, true);
 		if (err != SUCCESS)
 		{
 			free(pwd);
 			return (err);
 		}
-		err = ft_update_env_var(env_tab, oldpwd, 6);
+		err = ft_update_env_var(env_tab, oldpwd, 6, true);
 		if (err != SUCCESS)
 			return (err);
 	}

--- a/src/builtin_env.c
+++ b/src/builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/25 13:57:58 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/28 17:48:35 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 21:22:57 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,8 @@ t_err	ft_env(t_hashtable *env_tab)
 			tmp = env_tab->elements[i];
 			while (tmp != NULL)
 			{
-				printf("%s\n", tmp->env_string);
+				if (tmp->has_value)
+					printf("%s\n", tmp->env_string);
 				tmp = tmp->next;
 			}
 		}

--- a/src/builtin_export.c
+++ b/src/builtin_export.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/25 08:11:30 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/28 17:49:33 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 18:06:59 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -148,11 +148,11 @@ t_err	ft_check_and_update_env(char *str, t_hashtable *env_tab)
 	temp = ft_strdup(str);
 	if (!temp)
 		return (ERR_MALLOC);
-	err = ft_update_env_var(env_tab, temp, keylen);
+	if (temp[keylen] == '=')
+		err = ft_update_env_var(env_tab, temp, keylen, true);
+	else
+		err = ft_update_env_var(env_tab, temp, keylen, false);
 	if (err != SUCCESS)
-	{
 		free(temp);
-		return (err);
-	}
-	return (SUCCESS);
+	return (err);
 }

--- a/src/builtin_export.c
+++ b/src/builtin_export.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/25 08:11:30 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 18:06:59 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 21:39:10 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,7 +74,7 @@ t_err	ft_print_env_sorted(t_hashtable *env_tab)
 	t_err	err;
 
 	envp = NULL;
-	err = ft_envp_create(env_tab, &envp);
+	err = ft_envp_create_all(env_tab, &envp);
 	if (err != SUCCESS)
 		return (ft_export_error(err, NULL));
 	ft_quicksort_strings(envp, 0, env_tab->num_elements - 1);

--- a/src/builtin_utils.c
+++ b/src/builtin_utils.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 18:24:50 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/28 17:51:28 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 18:05:35 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,16 +66,17 @@ t_err	ft_get_env_keylen(char *str, size_t *len)
  * @return t_err SUCCESS, ERR_EMPTY, ERR_MALLOC, ERR_HT_NO_SWAP,
  * ERR_HT_NO_INSERT.
  */
-t_err	ft_update_env_var(t_hashtable *env_tab, char *env_str, size_t keylen)
+t_err	ft_update_env_var(t_hashtable *env_tab,
+		char *env_str, size_t keylen, bool has_value)
 {
 	t_env_var	*env_var;
 	t_err		err;
 
 	env_var = ft_hashtable_lookup(env_tab, env_str, keylen);
 	if (env_var)
-		err = ft_hashtable_swap(env_tab, env_str, keylen);
+		err = ft_hashtable_swap(env_tab, env_str, keylen, has_value);
 	else
-		err = ft_hashtable_insert(env_tab, env_str, keylen);
+		err = ft_hashtable_insert(env_tab, env_str, keylen, has_value);
 	return (err);
 }
 

--- a/src/env_envp.c
+++ b/src/env_envp.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/27 18:09:38 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 20:26:45 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 21:42:20 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@
  * @param envp Where to save pointers.
  * @return t_err SUCCESS
  */
-t_err	ft_envp_fill(t_hashtable *ht, char **envp)
+t_err	ft_envp_fill(t_hashtable *ht, char **envp, bool all)
 {
 	uint32_t	i;
 	t_env_var	*tmp;
@@ -41,7 +41,7 @@ t_err	ft_envp_fill(t_hashtable *ht, char **envp)
 			tmp = ht->elements[i];
 			while (tmp != NULL)
 			{
-				if (tmp->has_value)
+				if (all || tmp->has_value)
 					*envp++ = tmp->env_string;
 				tmp = tmp->next;
 			}
@@ -56,7 +56,7 @@ t_err	ft_envp_fill(t_hashtable *ht, char **envp)
  * @brief Create a NULL-terminated environment pointer (envp)
  *
  * Malloc char array of num_values of hashtable plus 1 for terminator.
- * Fetch all elements with ft_envp_fill().
+ * Fetch all elements with ft_envp_fill() with switch set to false.
  * @param ht Environment from which to copy.
  * @param envp Pointer to char**, where to save.
  * @return t_err ERR_EMPTY, ERR_MALLOC, SUCCESS
@@ -68,10 +68,31 @@ t_err	ft_envp_create(t_hashtable *ht, char ***envp)
 	*envp = malloc(sizeof(char *) * (ht->num_values + 1));
 	if (!*envp)
 		return (ERR_MALLOC);
-	ft_envp_fill(ht, *envp);
+	ft_envp_fill(ht, *envp, false);
 	return (SUCCESS);
 }
 
+/**
+ * @brief Create envp of all elements
+ *
+ * See also ft_envp_create().
+ * Difference: includes all elements of hashtable.
+ * Malloc char array of num_elements of hashtable plus 1 for terminator.
+ * Fetch all elements with ft_envp_fill() with switch set to true.
+ * @param ht Environment from which to copy.
+ * @param envp Pointer to char**, where to save.
+ * @return t_err ERR_EMPTY, ERR_MALLOC, SUCCESS
+ */
+t_err	ft_envp_create_all(t_hashtable *ht, char ***envp)
+{
+	if (!ht || !envp)
+		return (ERR_EMPTY);
+	*envp = malloc(sizeof(char *) * (ht->num_elements + 1));
+	if (!*envp)
+		return (ERR_MALLOC);
+	ft_envp_fill(ht, *envp, true);
+	return (SUCCESS);
+}
 /**
  * @brief Destroy envp.
  *

--- a/src/env_envp.c
+++ b/src/env_envp.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_envp.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/27 18:09:38 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/21 14:50:57 by sqiu             ###   ########.fr       */
+/*   Updated: 2023/08/12 20:26:45 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,11 @@
 /**
  * @brief Loop through all elements and copy the pointers.
  *
+ * The hashtable has an elements array, which are all linked lists.
+ * The function has to loop trhough the whole array.
+ * And per array it has to loop through the linked list.
+ * This function only copies the pointers in the hashtable.
+ * Only variables which have a value are copied.
  * @param ht Environment table which to copy.
  * @param envp Where to save pointers.
  * @return t_err SUCCESS
@@ -36,7 +41,8 @@ t_err	ft_envp_fill(t_hashtable *ht, char **envp)
 			tmp = ht->elements[i];
 			while (tmp != NULL)
 			{
-				*envp++ = tmp->env_string;
+				if (tmp->has_value)
+					*envp++ = tmp->env_string;
 				tmp = tmp->next;
 			}
 		}
@@ -47,11 +53,10 @@ t_err	ft_envp_fill(t_hashtable *ht, char **envp)
 }
 
 /**
- * @brief Malloc a NULL-terminated envp
+ * @brief Create a NULL-terminated environment pointer (envp)
  *
- * Malloc num_elements of hashtable plus 1 for terminator.
+ * Malloc char array of num_values of hashtable plus 1 for terminator.
  * Fetch all elements with ft_envp_fill().
- *
  * @param ht Environment from which to copy.
  * @param envp Pointer to char**, where to save.
  * @return t_err ERR_EMPTY, ERR_MALLOC, SUCCESS
@@ -60,7 +65,7 @@ t_err	ft_envp_create(t_hashtable *ht, char ***envp)
 {
 	if (!ht || !envp)
 		return (ERR_EMPTY);
-	*envp = malloc(sizeof(char *) * (ht->num_elements + 1));
+	*envp = malloc(sizeof(char *) * (ht->num_values + 1));
 	if (!*envp)
 		return (ERR_MALLOC);
 	ft_envp_fill(ht, *envp);
@@ -73,7 +78,6 @@ t_err	ft_envp_create(t_hashtable *ht, char ***envp)
  * Check if envp exists. If yes:
  * Free the envp and set to NULL.
  * Does not free elements.
- *
  * @param envp The pointer to free.
  * @return t_err SUCCESS
  */

--- a/src/env_shlvl.c
+++ b/src/env_shlvl.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 13:45:31 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/21 13:35:03 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 18:09:21 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,13 +75,13 @@ t_err	ft_increment_shlvl(t_hashtable *env_table)
 	if (new_val > MAX_SHLVL)
 	{
 		printf(MAX, new_val);
-		return (ft_hashtable_swap(env_table, "SHLVL=1", 5));
+		return (ft_hashtable_swap(env_table, "SHLVL=1", 5, true));
 	}
 	new_str = NULL;
 	err = ft_create_env_shlvl(&new_str, new_val);
 	if (err != SUCCESS)
 		return (err);
-	err = ft_hashtable_swap(env_table, new_str, 5);
+	err = ft_hashtable_swap(env_table, new_str, 5, true);
 	if (err != SUCCESS)
 		return (err);
 	return (SUCCESS);

--- a/src/hashtable_generate.c
+++ b/src/hashtable_generate.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/15 18:13:36 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/07 11:19:41 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 20:16:18 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,6 +62,7 @@ t_hashtable	*ft_hashtable_create(uint32_t size, t_hashfunction *hf)
 	ht->size = size;
 	ht->hash = hf;
 	ht->num_elements = 0;
+	ht->num_values = 0;
 	ht->elements = ft_calloc(sizeof(t_env_var *), ht->size);
 	if (!ht->elements)
 	{

--- a/src/hashtable_utils.c
+++ b/src/hashtable_utils.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/19 11:17:06 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 17:01:15 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 18:01:26 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -159,7 +159,8 @@ t_err	ft_hashtable_delete(
  * @param keylen Length of the key.
  * @return t_err ERR_EMPTY, ERR_HT_NO_SWAP, SUCCESS
  */
-t_err	ft_hashtable_swap(t_hashtable *ht, char *string, size_t keylen)
+t_err	ft_hashtable_swap(t_hashtable *ht,
+		char *string, size_t keylen, bool has_value)
 {
 	t_env_var	*env_var;
 
@@ -170,6 +171,10 @@ t_err	ft_hashtable_swap(t_hashtable *ht, char *string, size_t keylen)
 		return (ERR_HT_NO_SWAP);
 	free(env_var->env_string);
 	env_var->env_string = string;
-	env_var->value = string + keylen + 1;
+	env_var->has_value = has_value;
+	if (env_var->has_value)
+		env_var->value = string + keylen + 1;
+	else
+		env_var->value = "";
 	return (SUCCESS);
 }

--- a/src/hashtable_utils.c
+++ b/src/hashtable_utils.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/19 11:17:06 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 18:01:26 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 20:20:46 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,8 @@ t_err	ft_hashtable_insert(t_hashtable *ht,
 	env_var->next = ht->elements[index];
 	ht->elements[index] = env_var;
 	ht->num_elements++;
+	if (env_var->has_value)
+		ht->num_values++;
 	return (SUCCESS);
 }
 
@@ -145,6 +147,8 @@ t_err	ft_hashtable_delete(
 	free(tmp->env_string);
 	free(tmp);
 	ht->num_elements--;
+	if (tmp->has_value)
+		ht->num_values--;
 	return (SUCCESS);
 }
 
@@ -163,6 +167,7 @@ t_err	ft_hashtable_swap(t_hashtable *ht,
 		char *string, size_t keylen, bool has_value)
 {
 	t_env_var	*env_var;
+	bool		had_value;
 
 	if (!ht || !string || !keylen)
 		return (ERR_EMPTY);
@@ -171,10 +176,15 @@ t_err	ft_hashtable_swap(t_hashtable *ht,
 		return (ERR_HT_NO_SWAP);
 	free(env_var->env_string);
 	env_var->env_string = string;
+	had_value = env_var->has_value;
 	env_var->has_value = has_value;
 	if (env_var->has_value)
 		env_var->value = string + keylen + 1;
 	else
 		env_var->value = "";
+	if (had_value != has_value && has_value == true)
+		ht->num_values++;
+	else if (had_value != has_value && has_value == false)
+		ht->num_values--;
 	return (SUCCESS);
 }

--- a/src/hashtable_utils.c
+++ b/src/hashtable_utils.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/19 11:17:06 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/28 17:55:29 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 17:01:15 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
  * @brief Utils functions to use with env hashtable
  */
 
-#include "minishell.h"
+#include "hashtable.h"
 
 /**
  * @brief Generate index in hashtable of given string via hashfunction.
@@ -46,7 +46,8 @@ size_t	ft_hashtable_index(t_hashtable *ht, const char *key, size_t keylen)
  * @param keylen Length of env_var (everything before =)
  * @return t_err SUCCESS, ERR_EMPTY, ERR_MALLOC, ERR_HT_NO_INSERT
  */
-t_err	ft_hashtable_insert(t_hashtable *ht, char *string, size_t keylen)
+t_err	ft_hashtable_insert(t_hashtable *ht,
+		char *string, size_t keylen, bool has_value)
 {
 	size_t		index;
 	t_env_var	*env_var;
@@ -61,7 +62,11 @@ t_err	ft_hashtable_insert(t_hashtable *ht, char *string, size_t keylen)
 		return (ERR_MALLOC);
 	env_var->env_string = string;
 	env_var->keylen = keylen;
-	env_var->value = string + keylen + 1;
+	env_var->has_value = has_value;
+	if (env_var->has_value)
+		env_var->value = string + keylen + 1;
+	else
+		env_var->value = "";
 	env_var->next = ht->elements[index];
 	ht->elements[index] = env_var;
 	ht->num_elements++;

--- a/tests/test_builtin_unset.c
+++ b/tests/test_builtin_unset.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/25 13:17:27 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/05 21:00:21 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 20:00:01 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,11 +38,11 @@ void	test_builtin_unset(void)
 	test_setup_argv(5);
 	g_argv[0] = "unset";
 	g_argv[4] = NULL;
-	ft_hashtable_insert(g_symtab, ft_strdup("uno=this"), 3);
-	ft_hashtable_insert(g_symtab, ft_strdup("dos=is"), 3);
-	ft_hashtable_insert(g_symtab, ft_strdup("tr3s=sparta"), 4);
-	ft_hashtable_insert(g_symtab, ft_strdup("quatro=!"), 6);
-	ft_hashtable_insert(g_symtab, ft_strdup("sneaky=boy"), 6);
+	ft_hashtable_insert(g_symtab, ft_strdup("uno=this"), 3, true);
+	ft_hashtable_insert(g_symtab, ft_strdup("dos=is"), 3, true);
+	ft_hashtable_insert(g_symtab, ft_strdup("tr3s=sparta"), 4, true);
+	ft_hashtable_insert(g_symtab, ft_strdup("quatro=!"), 6, true);
+	ft_hashtable_insert(g_symtab, ft_strdup("sneaky=boy"), 6, true);
 	test_hashtable_pretty_print(g_symtab);
 	exec_ft_unset("Unset one var", "uno", NULL, NULL);
 	exec_ft_unset("Unset three vars", "dos", "tr3s", "quatro");

--- a/tests/test_env_envp.c
+++ b/tests/test_env_envp.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/28 08:17:46 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 19:57:00 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 21:07:55wolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,6 @@ void	test_env_envp_two(void)
 {
 	size_t		i;
 
-	ft_hashtable_insert(g_symtab, "TEST=This is a value", 4, true);
-	ft_hashtable_insert(g_symtab, "TEST2=Another value", 5, true);
 	ft_envp_create(g_symtab, &g_envp);
 	printf("This is envp[0]: %p\n", g_envp[0]);
 	printf("This is envp[1]: %p\n", g_envp[1]);
@@ -42,9 +40,25 @@ void	test_env_envp_empty(void)
 	ft_envp_destroy(&g_envp);
 }
 
+void	exec_envp_create(char *name)
+{
+	printf("TEST: %s\n", name);
+	ft_envp_create(g_symtab, &g_envp);
+	test_print_str_array(g_envp);
+	ft_envp_destroy(&g_envp);
+	printf("\n");
+}
+
 void	test_env_envp(void)
 {
-	g_symtab = ft_hashtable_create(10, ft_hash_fnv1);
-	//test_env_envp_empty();
-	test_env_envp_two();
+	g_symtab = ft_hashtable_create(100, ft_hash_fnv1);
+	exec_envp_create("Empty environment");
+	ft_hashtable_insert(g_symtab, ft_strdup("TEST=This is a value"), 4, true);
+	ft_hashtable_insert(g_symtab, ft_strdup("TEST2=Another value"), 5, true);
+	exec_envp_create("Two vars");
+	ft_hashtable_insert(g_symtab, ft_strdup("NOVAL"), 5, false);
+	exec_envp_create("Three vars, one no value");
+	ft_hashtable_swap(g_symtab, ft_strdup("TEST"), 4, false);
+	exec_envp_create("Three vars, two no value");
+	//ft_hashtable_destroy(g_symtab);
 }

--- a/tests/test_env_envp.c
+++ b/tests/test_env_envp.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/28 08:17:46 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/18 03:12:05 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 19:57:00 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,8 @@ void	test_env_envp_two(void)
 {
 	size_t		i;
 
-	ft_hashtable_insert(g_symtab, "TEST=This is a value", 4);
-	ft_hashtable_insert(g_symtab, "TEST2=Another value", 5);
+	ft_hashtable_insert(g_symtab, "TEST=This is a value", 4, true);
+	ft_hashtable_insert(g_symtab, "TEST2=Another value", 5, true);
 	ft_envp_create(g_symtab, &g_envp);
 	printf("This is envp[0]: %p\n", g_envp[0]);
 	printf("This is envp[1]: %p\n", g_envp[1]);

--- a/tests/test_executor.c
+++ b/tests/test_executor.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   test_executor.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/31 13:17:27 by sqiu              #+#    #+#             */
-/*   Updated: 2023/08/11 10:55:56 by sqiu             ###   ########.fr       */
+/*   Updated: 2023/08/12 20:00:35 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -99,7 +99,7 @@ static int	test_scmd_wrapper(char *testname, char *test)
 	test_setup_data();
 /* 	if (!ft_strncmp(test, "minishell", 9))
 		ft_hashtable_delete(g_data.env_table, "PATH", 4); */
-	ft_hashtable_swap(g_data.env_table, "PATH=:/usr/lib/", 4);
+	ft_hashtable_swap(g_data.env_table, "PATH=:/usr/lib/", 4, true);
 	ft_envp_create(g_data.env_table, &g_data.envp);
 	printf("TEST: %s\n", testname);
 	printf("Command:%s\n\n", test);

--- a/tests/test_expand.c
+++ b/tests/test_expand.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/20 08:58:42 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/11 16:11:15 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 19:59:18 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,10 +35,10 @@ void	test_expand_list(void)
 
 	printf(YELLOW"*******TEST_EXPAND_TKN_LIST*******\n\n"RESET);
 	g_symtab = ft_hashtable_create(1, ft_hash_fnv1);
-	ft_hashtable_insert(g_symtab, "TEST=USER    SPACEMAN", 4);
-	ft_hashtable_insert(g_symtab, "A=at -e", 1);
-	ft_hashtable_insert(g_symtab, "LOGFILE=/usr/log/logfile.txt", 7);
-	ft_hashtable_insert(g_symtab, "HOME=/usr/home", 4);
+	ft_hashtable_insert(g_symtab, "TEST=USER    SPACEMAN", 4, true);
+	ft_hashtable_insert(g_symtab, "A=at -e", 1, true);
+	ft_hashtable_insert(g_symtab, "LOGFILE=/usr/log/logfile.txt", 7, true);
+	ft_hashtable_insert(g_symtab, "HOME=/usr/home", 4, true);
 	//HEREDOC
 	exec_expand_tkn_lst("Heredoc quote removal", "<< 'hello' cat");
 	//REDIRECT

--- a/tests/test_expand_expander.c
+++ b/tests/test_expand_expander.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/13 20:43:06 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/11 18:34:41 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 19:57:54 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,9 +48,9 @@ void	test_expand_tilde(funptr_expand_t funptr_expand)
 	printf(BLUE"**\tTILDE\t**\n\n"RESET);
 	g_err_count += exec_expand("no HOME set", "~", "~", funptr_expand);
 
-	ft_hashtable_insert(g_symtab, ft_strdup("HOME=/this/is/home"), 4);
-	ft_hashtable_insert(g_symtab, ft_strdup("PWD=/this/is/PWD"), 3);
-	ft_hashtable_insert(g_symtab, ft_strdup("OLDPWD=/this/is/OLDPWD"), 6);
+	ft_hashtable_insert(g_symtab, ft_strdup("HOME=/this/is/home"), 4, true);
+	ft_hashtable_insert(g_symtab, ft_strdup("PWD=/this/is/PWD"), 3, true);
+	ft_hashtable_insert(g_symtab, ft_strdup("OLDPWD=/this/is/OLDPWD"), 6, true);
 	g_err_count += exec_expand("expand $HOME with ~", "~", "/this/is/home", funptr_expand);
 	g_err_count += exec_expand("expand $PWD with ~+", "~+", "/this/is/PWD", funptr_expand);
 	g_err_count += exec_expand("expand $OLDPWD with ~-", "~-", "/this/is/OLDPWD", funptr_expand);
@@ -62,7 +62,7 @@ void	test_expand_tilde(funptr_expand_t funptr_expand)
 void	test_expand_var(funptr_expand_t funptr_expand)
 {
 	printf(BLUE"**\tVARS\t**\n\n"RESET);
-	ft_hashtable_insert(g_symtab, ft_strdup("TEST='I am test'"), 4);
+	ft_hashtable_insert(g_symtab, ft_strdup("TEST='I am test'"), 4, true);
 	g_err_count += exec_expand("simple var expansion", "$TEST", "'I am test'", funptr_expand);
 	g_err_count += exec_expand("double var", "$TEST$TEST", "'I am test''I am test'", funptr_expand);
 	g_err_count += exec_expand("empty var", "$NO_VAR", "", funptr_expand);

--- a/tests/test_expand_handler.c
+++ b/tests/test_expand_handler.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/05 13:09:02 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/11 11:18:26 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 19:58:49 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -98,9 +98,9 @@ void	test_expand_handler(void)
 {
 	printf(YELLOW"*******TEST_EXPAND_HANDLER*******\n\n"RESET);
 	g_symtab = ft_hashtable_create(1, ft_hash_fnv1);
-	ft_hashtable_insert(g_symtab, ft_strdup("TEST=I   have    spaces"), 4);
-	ft_hashtable_insert(g_symtab, ft_strdup("S=s -la"), 1);
-	ft_hashtable_insert(g_symtab, ft_strdup("SINGLE=badboy'"), 6);
+	ft_hashtable_insert(g_symtab, ft_strdup("TEST=I   have    spaces"), 4, true);
+	ft_hashtable_insert(g_symtab, ft_strdup("S=s -la"), 1, true);
+	ft_hashtable_insert(g_symtab, ft_strdup("SINGLE=badboy'"), 6, true);
 
 	test_handle_arg();
 	test_handle_heredoc();

--- a/tests/test_hashtable.c
+++ b/tests/test_hashtable.c
@@ -6,12 +6,13 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/06 13:29:52 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/05 21:00:21 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 19:48:16 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "test.h"
 
+extern t_hashtable	*g_symtab;
 /**
  * @brief Pretty print all elements.
  *
@@ -49,19 +50,30 @@ void	test_hashtable_pretty_print(t_hashtable *ht)
 	printf("End Table\n");
 }
 
-void	test_hashtable(void)
+void	test_insert_one(char *name, char *env_str, size_t keylen, bool has_value)
 {
-	t_hashtable	*sym_tab;
 	t_env_var	*env_var;
 
-	sym_tab = ft_hashtable_create(100, ft_hash_fnv1);
-
-	ft_hashtable_insert(sym_tab, ft_strdup("TEST=Ima testing"), 4);
-	env_var = ft_hashtable_lookup(sym_tab, "TEST", 4);
+ 	printf("TEST: %s\n", name);
+	ft_hashtable_insert(g_symtab, ft_strdup(env_str), keylen, has_value);
+	env_var = ft_hashtable_lookup(g_symtab, env_str, keylen);
 	if (env_var == NULL)
-		printf("not found\n");
+		printf("Var was not found\n");
 	else
-		printf("TEST was found\n");
-	ft_hashtable_delete(sym_tab, "TEST", 4);
-	ft_hashtable_destroy(sym_tab);
+	{
+		printf("Var was found!\n");
+		printf("String:\t%s\nValue:\t%s\n", env_var->env_string, env_var->value);
+	}
+	ft_hashtable_delete(g_symtab, env_str, keylen);
+}
+
+void	test_hashtable(void)
+{
+
+	g_symtab = ft_hashtable_create(100, ft_hash_fnv1);
+	test_insert_one("Simple insert", "TEST=I am test", 4, true);
+	test_insert_one("No value", "NOVAL=", 5, true);
+	test_insert_one("No equals", "OHNO", 4, false);
+
+	ft_hashtable_destroy(g_symtab);
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/02 10:40:30 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 16:29:09 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 20:58:07 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,14 +90,28 @@ void	test_print_tkn_list(t_tkn_list *head)
 	printf("-> NULL\n\n");
 }
 
+void	test_print_str_array(char **array)
+{
+	int	i;
+
+	i = 0;
+	if (array[0] == NULL)
+		printf("EMPTY\n");
+	while (array[i])
+	{
+		printf("%i: %s\n", i, array[i]);
+		i++;
+	}
+}
+
 int	main(void)
 {
 	//test_buffer();
-	test_hashtable();
+	//test_hashtable();
 	//test_replace_token();
 	//test_prompt();
 	//test_check_syntax();
-	//test_env_envp();
+	test_env_envp();
 	//test_lexer();
 	//test_expand_list();
 	//test_expand_expander();

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/02 10:40:30 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/11 16:09:36 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 16:29:09 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,13 +93,13 @@ void	test_print_tkn_list(t_tkn_list *head)
 int	main(void)
 {
 	//test_buffer();
-	//test_hashtable();
+	test_hashtable();
 	//test_replace_token();
 	//test_prompt();
 	//test_check_syntax();
 	//test_env_envp();
 	//test_lexer();
-	test_expand_list();
+	//test_expand_list();
 	//test_expand_expander();
 	//test_expand_field_split();
 	//test_expand_handler();

--- a/tests/test_prompt.c
+++ b/tests/test_prompt.c
@@ -6,115 +6,49 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/06 13:11:47 by gwolf             #+#    #+#             */
-/*   Updated: 2023/07/21 13:59:16 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 19:46:30 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "test.h"
 
+extern t_hashtable	*g_symtab;
+
+void	exec_prompt_create(char *name, char *env_str, int num, char *expect)
+{
+	char	*prompt;
+
+	prompt = NULL;
+	printf("TEST: %s\n", name);
+	printf("env_str: %s\n", env_str);
+	ft_hashtable_insert(g_symtab, env_str, 3, true);
+	if (num == 1)
+		ft_prompt_create(g_symtab, &prompt, "PS1", PS1_STD);
+	else
+		ft_prompt_create(g_symtab, &prompt, "PS2", PS2_STD);
+	printf("Prompt: %s\n", prompt);
+	free(prompt);
+}
+
 void	test_prompt(void)
 {
-	t_hashtable	*sym_tab;
-	char		*prompt;
-
-	sym_tab = ft_hashtable_create(100, ft_hash_fnv1);
-	prompt = NULL;
-	printf("\nNo var PS1 or PS2\n");
-	{
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("This is empty prompt PS1: %s\n", prompt);
-		free(prompt);
-		ft_prompt_create(sym_tab, &prompt, "PS2", PS2_STD);
-		printf("This is empty prompt PS2: %s\n", prompt);
-		free(prompt);
-	}
-	printf("\nSimple var for PS1 and PS2\n");
-	{
-		ft_hashtable_insert(sym_tab, ft_strdup("PS1=I'm testboy"), 3);
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("This is prompt PS1: %s\n", prompt);
-		ft_hashtable_delete(sym_tab, "PS1", 3);
-		free(prompt);
-		ft_hashtable_insert(sym_tab, ft_strdup("PS2=Be gentle!"), 3);
-		ft_prompt_create(sym_tab, &prompt, "PS2", PS2_STD);
-		printf("This is prompt PS2: %s\n", prompt);
-		ft_hashtable_delete(sym_tab, "PS2", 3);
-		free(prompt);
-	}
-	printf("\nConversion \\h\n");
-	{
-		printf("No SESSION_MANAGER\n");
-		ft_hashtable_insert(sym_tab, ft_strdup("PS1=\\h"), 3);
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=\\h: %s\n", prompt);
-		free(prompt);
-		ft_hashtable_insert(sym_tab, ft_strdup("SESSION_MANAGER=local/hello:"), 15);
-		printf("After insert of SESSION_MANAGER\n");
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=\\h: %s\n", prompt);
-		free(prompt);
-		ft_hashtable_swap(sym_tab, ft_strdup("SESSION_MANAGER=bye.thisis:local/nonono.maybe:"), 15);
-		printf("After swap of SESSION_MANAGER\n");
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=\\h: %s\n", prompt);
-		ft_hashtable_delete(sym_tab, "PS1", 3);
-		free(prompt);
-	}
-	printf("\nConversion \\u\n");
-	{
-		printf("No USER\n");
-		ft_hashtable_insert(sym_tab, ft_strdup("PS1=\\u"), 3);
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=\\u: %s\n", prompt);
-		free(prompt);
-		ft_hashtable_insert(sym_tab, ft_strdup("USER=Testboiii"), 4);
-		printf("After insert of USER\n");
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=\\u: %s\n", prompt);
-		free(prompt);
-		ft_hashtable_swap(sym_tab, ft_strdup("USER="), 4);
-		printf("Empty USER\n");
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=\\u: %s\n", prompt);
-		ft_hashtable_delete(sym_tab, "PS1", 3);
-		free(prompt);
-	}
-	printf("\nConversion \\w\n");
-	{
-		printf("No PWD\n");
-		ft_hashtable_insert(sym_tab, ft_strdup("PS1=\\w"), 3);
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=\\w: %s\n", prompt);
-		free(prompt);
-		ft_hashtable_insert(sym_tab, ft_strdup("PWD=nfs/homes/test"), 3);
-		printf("After insert of PWD but no HOME\n");
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=\\w: %s\n", prompt);
-		free(prompt);
-		ft_hashtable_insert(sym_tab, ft_strdup("HOME=nfs/homes"), 4);
-		printf("After insert of PWD and HOME\n");
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=\\w: %s\n", prompt);
-		ft_hashtable_delete(sym_tab, "PS1", 3);
-		free(prompt);
-	}
-	printf("\nWrong PS1 string - single backslash\n");
-	{
-		ft_hashtable_insert(sym_tab, ft_strdup("PS1=bad\\"), 3);
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=bad\\: %s\n", prompt);
-		ft_hashtable_delete(sym_tab, "PS1", 3);
-		free(prompt);
-	}
-	printf("\nWrong PS1 string - not supported\n");
-	{
-		ft_hashtable_insert(sym_tab, ft_strdup("PS1=no no\\z"), 3);
-		ft_prompt_create(sym_tab, &prompt, "PS1", PS1_STD);
-		printf("PS1=no no\\z: %s\n", prompt);
-		ft_hashtable_delete(sym_tab, "PS1", 3);
-		free(prompt);
-	}
-	ft_hashtable_destroy(sym_tab);
-
-
+	g_symtab = ft_hashtable_create(100, ft_hash_fnv1);
+	exec_prompt_create("No var for PS1", "NOVAR=", 1, "");
+	exec_prompt_create("No var for PS2", "NOVAR=", 2, "");
+	exec_prompt_create("Simple var for PS1", "PS1=I'm testboy ", 1, "I'm testboy ");
+	exec_prompt_create("Simple var for PS2", "PS2=Be gentle ", 2, "Be gentle ");
+	exec_prompt_create("\\h", "PS1=\\h ", 1, "hostname ");
+	exec_prompt_create("\\u - no user", "PS1=\\u ", 1, "hostname ");
+	ft_hashtable_insert(g_symtab, ft_strdup("USER=Testboiii"), 4, true);
+	exec_prompt_create("\\u - with user", "PS1=\\u ", 1, "Testboiii ");
+	ft_hashtable_swap(g_symtab, ft_strdup("USER="), 4, true);
+	exec_prompt_create("\\u - empty user", "PS1=\\u ", 1, " ");
+	exec_prompt_create("\\w - no PWD", "PS1=\\w ", 1, " ");
+	ft_hashtable_insert(g_symtab, ft_strdup("PWD=nfs/homes/test"), 3, true);
+	exec_prompt_create("\\w - PWD but no HOME", "PS1=\\w ", 1, " ");
+	ft_hashtable_insert(g_symtab, ft_strdup("HOME=nfs/homes"), 4, true);
+	exec_prompt_create("\\w - PWD and HOME", "PS1=\\w ", 1, " ");
+	exec_prompt_create("Wrong string - single backslash", "PS1=bad\\ ", 1, " ");
+	exec_prompt_create("Wrong string - not supported", "PS1=no \\z ", 1, " ");
+	ft_hashtable_destroy(g_symtab);
 }

--- a/tests/test_prompt.c
+++ b/tests/test_prompt.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/06 13:11:47 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/12 19:46:30 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/12 20:07:55 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,14 +20,15 @@ void	exec_prompt_create(char *name, char *env_str, int num, char *expect)
 
 	prompt = NULL;
 	printf("TEST: %s\n", name);
-	printf("env_str: %s\n", env_str);
-	ft_hashtable_insert(g_symtab, env_str, 3, true);
+	printf("VAR:\t%s\n", env_str);
+	ft_hashtable_insert(g_symtab, ft_strdup(env_str), 3, true);
 	if (num == 1)
 		ft_prompt_create(g_symtab, &prompt, "PS1", PS1_STD);
 	else
 		ft_prompt_create(g_symtab, &prompt, "PS2", PS2_STD);
-	printf("Prompt: %s\n", prompt);
+	printf("Prompt:\t%s\n\n", prompt);
 	free(prompt);
+	ft_hashtable_delete(g_symtab, env_str, 3);
 }
 
 void	test_prompt(void)


### PR DESCRIPTION
This branch solves an invalid read, with potential of SIGV, when an empty variable was added to the environment.

1. Update hashtable

`export a` exports a variable, but the variable has no value. This variable doesn't show up in the list printed by env, but does show up in the (non standard) list of export in bash --posix. Minishell now behaves the same.

- environment variables have a new bool `has_value` to check if they have a value. Depending on that bool the value pointer is set either after the equals sign or after the variable name. The has_value check has to be done before insertion. This bool needs to be passed to `hashtable_insert()` and `hashtable_swap()`.
- The hashtable counts the number of elements in the table with `num_elements`. Now it also counts the variables with value assigned with `num_values`.
- `ft_envp_create()` only adds variables which have a value into the envp. The new `ft_envp_create_all()` adds all variables to the array.
- `ft_env()` uses the first, `ft_export()` uses the latter function.

2. Refactor

Refactored tests to fit the new function prototypes of  `hashtable_insert()` and `hashtable_swap()`.

Closes #37