### PR TITLE
feat: check for directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/28 13:03:05 by gwolf             #+#    #+#              #
-#    Updated: 2023/08/13 22:49:18 by sqiu             ###   ########.fr        #
+#    Updated: 2023/08/15 16:10:45 by sqiu             ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -119,7 +119,8 @@ SRC :=	utils_memory.c \
 		tkn_list_create.c \
 		tkn_list_delete.c \
 		tkn_list_search.c \
-		signal.c
+		signal.c \
+		error_temp.c
 SRCS := $(addprefix $(SRC_DIR)/, $(SRC))
 
 # ******************************

--- a/inc/minishell_error.h
+++ b/inc/minishell_error.h
@@ -6,7 +6,7 @@
 /*   By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/24 11:58:28 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/15 11:34:41 by sqiu             ###   ########.fr       */
+/*   Updated: 2023/08/15 17:02:31 by sqiu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,8 +58,12 @@ typedef enum e_error {
 	ERR_SIGNAL, ///< Setup of signal handler failed.
 	ERR_NO_INPUT, ///< Input is empty.
 	ERR_ABORT, ///< Abort pipeline.
-	ERR_HEREDOC_EOF ///< Heredoc stopped by Ctrl+D
+	ERR_HEREDOC_EOF, ///< Heredoc stopped by Ctrl+D
+	ERR_DIR, ///< Cmd is a directory.
+	ERR_NO_DIR ///< Directory of file not found
 }	t_err;
 
+t_err	ft_print_warning(char *indic, char *trigger);
+t_err	ft_print_warning2(char *indic, char *trigger);
 
 #endif

--- a/inc/mod_executor.h
+++ b/inc/mod_executor.h
@@ -6,7 +6,7 @@
 /*   By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/31 11:04:32 by sqiu              #+#    #+#             */
-/*   Updated: 2023/08/15 12:32:50 by sqiu             ###   ########.fr       */
+/*   Updated: 2023/08/15 16:24:23 by sqiu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,9 @@
 
 # include "mod_handle_input.h"
 # include "mod_signal.h"
+
+# include <sys/types.h>
+# include <sys/stat.h>
 
 /* ====== Globals ====== */
 
@@ -53,7 +56,6 @@ t_err	ft_read_heredoc(char *delim, char *prompt2, int fd, char **name);
 t_err	ft_name_heredoc(int index, char **name);
 t_err	ft_initiate_heredoc(int index, char **name, int *fd);
 t_err	ft_heredoc_fate(t_cmd *cmd, char **name, int fd, int curr_delim);
-t_err	ft_print_warning(char *delim);
 
 // cleanup
 void	ft_cleanup_cmd_list(t_cmd *cmd);
@@ -73,6 +75,7 @@ t_err	ft_wait_for_babies(t_cmd *cmd);
 bool	ft_check_empty_path(char *path_str);
 t_err	ft_open_outfile(t_cmd *cmd);
 t_err	ft_loop_thru_outfiles(t_cmd *cmd);
+t_err	ft_check_dir(char **args);
 
 // builtins
 bool	ft_check_builtin(char *arg);

--- a/src/error_temp.c
+++ b/src/error_temp.c
@@ -1,0 +1,60 @@
+
+#include "mod_executor.h"
+
+/**
+ * @brief Print warning messages depending on 
+ * received indicator and trigger string.
+ * 
+ * @param indic		Indicator string for error message.
+ * @param trigger	Trigger string causing the error.
+ * @return t_err	ERR_HEREDOC_EOF, ERR_DIR, SUCCESS
+ */
+t_err	ft_print_warning(char *indic, char *trigger)
+{
+	if (!ft_strncmp(indic, "heredoc", 8))
+	{
+		ft_putstr_fd("minishell: warning: here-document at line 42 \
+	delimited by end-of-file (wanted `", 2);
+		ft_putstr_fd(trigger, 2);
+		ft_putendl_fd("')", 2);
+		return (ERR_HEREDOC_EOF);
+	}
+	else if (!ft_strncmp(indic, "dir", 4))
+	{
+		g_status = 126;
+		ft_putstr_fd("minishell: ", 2);
+		ft_putstr_fd(trigger, 2);
+		ft_putendl_fd(": Is a directory", 2);
+		return (ERR_DIR);
+	}
+	else
+		return (ft_print_warning2(indic, trigger));
+}
+
+/**
+ * @brief Continuation of ft_print_warning()
+ * 
+ * @param indic 	Indicator string for error message.
+ * @param trigger 	Trigger string causing the error.
+ * @return t_err 	ERR_DIR, SUCCESS
+ */
+t_err	ft_print_warning2(char *indic, char *trigger)
+{
+	if (!ft_strncmp(indic, "nodir", 6))
+	{
+		g_status = 127;
+		ft_putstr_fd("minishell: ", 2);
+		ft_putstr_fd(trigger, 2);
+		ft_putendl_fd(": No such file or directory", 2);
+		return (ERR_DIR);
+	}
+	if (!ft_strncmp(indic, "nocmd", 6))
+	{
+		g_status = 127;
+		ft_putstr_fd("minishell: ", 2);
+		ft_putstr_fd(trigger, 2);
+		ft_putendl_fd(": command not found", 2);
+		return (SUCCESS);
+	}
+	return (SUCCESS);
+}

--- a/src/executor.c
+++ b/src/executor.c
@@ -6,7 +6,7 @@
 /*   By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/31 11:04:05 by sqiu              #+#    #+#             */
-/*   Updated: 2023/08/15 11:59:17 by sqiu             ###   ########.fr       */
+/*   Updated: 2023/08/15 17:04:59 by sqiu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -158,14 +158,36 @@ t_err	ft_process_cmd(t_cmd *cmd, t_err err, t_data *data)
 {
 	if (err == ERR_MALLOC)
 		return (err);
+	else if (err == ERR_DIR)
+		return (SUCCESS);
 	else if (err == ERR_UNKNOWN_CMD)
 	{
-		write(2, "minishell: ", 11);
-		ft_putstr_fd(cmd->args[0], 2);
-		write(2, ": command not found\n", 20);
+		ft_print_warning("nocmd", cmd->args[0]);
 		err = ft_close(&cmd->fd_pipe[1]);
 	}
 	else if (err == SUCCESS)
 		err = ft_create_child(cmd, data, false);
 	return (err);
+}
+
+/**
+ * @brief Check whether the argument is a directory.
+ * 
+ * Stat() returns 0 if a directory was found, else -1.
+ * @param args 		Argument array containing the cmd.
+ * @return t_err 	ERR_DIR, SUCCESS
+ */
+t_err	ft_check_dir(char **args)
+{
+	struct stat	buf;
+
+	stat(args[0], &buf);
+	if (ft_strchr(args[0], '/'))
+	{
+		if (S_ISDIR(buf.st_mode))
+			return (ERR_DIR);
+		return (ERR_NO_DIR);
+	}
+	else
+		return (SUCCESS);
 }

--- a/src/executor_heredoc.c
+++ b/src/executor_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/05 11:05:42 by sqiu              #+#    #+#             */
-/*   Updated: 2023/08/15 12:53:30 by sqiu             ###   ########.fr       */
+/*   Updated: 2023/08/15 16:27:56 by sqiu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -102,7 +102,7 @@ t_err	ft_read_heredoc(char *delim, char *prompt2, int fd, char **name)
 		if (g_status == 130)
 			return (ft_unlink_heredoc(name, ERR_ABORT));
 		if (!buf)
-			return (ft_print_warning(delim));
+			return (ft_print_warning("heredoc", delim));
 		if (ft_strncmp(delim, buf, len + 1) == 0)
 			break ;
 		write(fd, buf, ft_strlen(buf));

--- a/src/executor_heredoc2.c
+++ b/src/executor_heredoc2.c
@@ -6,7 +6,7 @@
 /*   By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/12 00:20:14 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/14 11:31:30 by sqiu             ###   ########.fr       */
+/*   Updated: 2023/08/15 16:10:02 by sqiu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,23 +37,4 @@ t_err	ft_initiate_heredoc(int index, char **name, int *fd)
 	if (*fd < 0)
 		return (ERR_OPEN);
 	return (SUCCESS);
-}
-
-/**
- * @brief Print warning message when EOF is
- * encountered while heredoc is reading from STDIN.
- *
- * Print prompt2.
- * Then print the warning message with
- * expected the delimiter.
- * @param delim		Delimiter string of heredoc.
- * @return t_err	ERR_HEREDOC_EOF
- */
-t_err	ft_print_warning(char *delim)
-{
-	ft_putstr_fd("minishell: warning: here-document at line 42 \
-delimited by end-of-file (wanted `", 2);
-	ft_putstr_fd(delim, 2);
-	ft_putstr_fd("')\n", 2);
-	return (ERR_HEREDOC_EOF);
 }

--- a/src/executor_utils.c
+++ b/src/executor_utils.c
@@ -6,7 +6,7 @@
 /*   By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/01 18:03:04 by sqiu              #+#    #+#             */
-/*   Updated: 2023/08/13 15:38:19 by sqiu             ###   ########.fr       */
+/*   Updated: 2023/08/15 17:09:04 by sqiu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,9 @@
 /**
  * @brief Check given args executable.
  * 
- * Iterate through cmd_paths. If one or more paths are empty (""),
+ * First check if cmd is a directory/a non-existing directory. If so, 
+ * exit the function.
+ * If not iterate through cmd_paths. If one or more paths are empty (""),
  * boolean "empty_path" is set to true.
  * If args executable contains an absolute path (starts with /),
  * a relative path (starts with ./ or ../), no paths are given or empty_path
@@ -39,6 +41,10 @@ t_err	ft_check_cmd_access(char **args, char **cmd_paths, bool empty_path)
 {
 	t_err	err;
 
+	if (ft_check_dir(args) == ERR_DIR)
+		return (ft_print_warning("dir", args[0]));
+	else if (ft_check_dir(args) == ERR_NO_DIR)
+		return (ft_print_warning("nodir", args[0]));
 	err = ERR_UNKNOWN_CMD;
 	if ((*args)[0] == '/' || !ft_strncmp(*args, "./", 2)
 		|| !ft_strncmp(*args, "../", 3) || !cmd_paths || empty_path)


### PR DESCRIPTION
Added ability to check given input (args) for directories utilising stat() and its Macro S_ISDIR:

* If contains '/': check for directory
If yes, print according message "Is a directory". Exit status = 126
If not found, print according message "No such file or directory". Exit status 127
* Else continue to check if it's a vaild cmd. 
If yes, execute cmd. 
If not, print according message "command not found". Exit status 127

Has potential to refactor by pulling the directory check out of ft_check_cmd_access(). Follows after refactor of ft_execute_scmd() and ft_execute_pcmd()

Close #52 