### PR TITLE
73 ambiguous redirect

### DIFF
--- a/inc/mod_parser.h
+++ b/inc/mod_parser.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 12:06:32 by sqiu              #+#    #+#             */
-/*   Updated: 2023/08/26 19:57:02 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/27 10:53:38 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,7 @@ t_err	ft_save_infile(t_tkn_list **lst, t_cmd *new);
 t_err	ft_save_heredoc(t_tkn_list **lst, t_cmd *new);
 t_err	ft_save_outfile(t_tkn_list **lst, t_cmd *new, bool append);
 t_err	ft_save_arg(t_tkn_list *lst, t_cmd *new);
+t_err	ft_handle_ambiguous(t_tkn_list **lst, t_cmd *new);
 
 // helpers
 t_cmd	*ft_last_cmd(t_cmd *cmd);

--- a/src/expand_types.c
+++ b/src/expand_types.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/26 13:05:50 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/26 13:08:08 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/27 10:42:55 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,14 +61,22 @@ t_err	ft_expand_heredoc(t_tkn_list **node)
 t_err	ft_expand_redirect(t_tkn_list **node, t_hashtable *symtab)
 {
 	t_track	input;
+	char	*tmp;
 
 	*node = (*node)->next;
 	ft_init_tracker(&input, (*node)->content, INFILE);
+	tmp = NULL;
+	if (ft_err_strdup(input.str, &tmp, "minishell: malloc") == ERR_MALLOC)
+		return (ERR_MALLOC);
 	if (ft_expander(&input, symtab, input.type) == ERR_MALLOC)
 		return (ERR_MALLOC);
 	(*node)->content = input.str;
 	if ((*node)->content[0] == '\0' && !input.found_quote)
+	{
+		ft_print_warning(ERR_AMBIGUOUS, tmp);
 		(*node)->prev->type = AMBIGUOUS;
+	}
+	free (tmp);
 	return (SUCCESS);
 }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/23 13:13:28 by sqiu              #+#    #+#             */
-/*   Updated: 2023/08/25 20:09:06 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/27 10:53:56 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -124,6 +124,8 @@ t_err	ft_categorise(t_tkn_list **lst, t_cmd *new, bool *cmd_complete)
 		err = ft_save_infile(&tmp, new);
 	else if (tmp->type == OUTFILE)
 		err = ft_save_outfile(&tmp, new, false);
+	else if (tmp->type == AMBIGUOUS)
+		err = ft_handle_ambiguous(&tmp, new);
 	else if (tmp->type == APPEND)
 		err = ft_save_outfile(&tmp, new, true);
 	else if (tmp->type == PIPE)

--- a/src/parser_fill_cmd.c
+++ b/src/parser_fill_cmd.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 14:59:22 by sqiu              #+#    #+#             */
-/*   Updated: 2023/08/26 13:48:58 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/27 10:56:46 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -118,5 +118,20 @@ t_err	ft_save_arg(t_tkn_list *lst, t_cmd *new)
 	if (!new->args[new->arg_pos])
 		return (ERR_MALLOC);
 	new->arg_pos++;
+	return (SUCCESS);
+}
+
+/**
+ * @brief Set cmd to no execute if ambiguous redirect.
+ *
+ * Needs to return SUCCESS for loop in calling funciton.
+ * @param lst		List of token.
+ * @param new		New cmd to be filled.
+ * @return t_err	SUCCESS.
+ */
+t_err	ft_handle_ambiguous(t_tkn_list **lst, t_cmd *new)
+{
+	*lst = (*lst)->next;
+	new->execute = false;
 	return (SUCCESS);
 }

--- a/src/parser_utils.c
+++ b/src/parser_utils.c
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 13:15:09 by sqiu              #+#    #+#             */
-/*   Updated: 2023/08/26 20:48:03 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/08/27 11:23:46 by gwolf            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,7 +59,7 @@ void	ft_count_str(t_tkn_list *lst, int *count_arg, int *count_delim,
 		}
 		else if (lst->type == PIPE)
 			return ;
-		else if (lst->type == INFILE)
+		else if (lst->type == INFILE || lst->type == AMBIGUOUS)
 			lst = lst->next;
 		else if (lst->type == OUTFILE || lst->type == APPEND)
 		{


### PR DESCRIPTION
Handle ambiguous redirects:
- Save filename before expanding, print error message when empty expand and set node type to AMBIGUOUS
- Parser ignores AMBIGUOUS node and next one, while counting arg size and sets cmd to no execute 