### PR TITLE
fix: include stdio before readline

### DIFF
--- a/inc/mod_cleanup.h
+++ b/inc/mod_cleanup.h
@@ -6,7 +6,7 @@
 /*   By: gwolf <gwolf@student.42vienna.com>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/05 17:33:17 by sqiu              #+#    #+#             */
-/*   Updated: 2023/08/26 20:20:42 by gwolf            ###   ########.fr       */
+/*   Updated: 2023/09/08 12:08:00 by phnowak          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 /* ====== Includes ====== */
 
 # include <stdbool.h>
+# include <stdio.h>
 # include <readline/history.h>
 # include "minishell_error.h"
 # include "libft.h"

--- a/inc/mod_signal.h
+++ b/inc/mod_signal.h
@@ -6,7 +6,7 @@
 /*   By: sqiu <sqiu@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/21 16:59:36 by gwolf             #+#    #+#             */
-/*   Updated: 2023/08/13 19:06:12 by sqiu             ###   ########.fr       */
+/*   Updated: 2023/09/08 12:08:19 by phnowak          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,7 @@
 
 # include <stddef.h>
 # include <unistd.h>
+# include <stdio.h>
 # include <readline/readline.h>
 # include <sys/ioctl.h>
 # include <signal.h>


### PR DESCRIPTION
The inclusion of stdio before readline is necessary to ensure compilation on all linux distributions.

fix for issue #80 